### PR TITLE
error: ‘CreateGlutWindowAndBind’ is not a member of ‘pangolin’

### DIFF
--- a/README
+++ b/README
@@ -90,7 +90,7 @@ features and to make it better.
  $ cd Pangolin
  $ mkdir BUILD
  $ cd BUILD
- $ cmake ..
+ $ cmake -DCPP11_NO_BOOST=1 -DFORCE_GLUT=1 ..
  $ make -j4
  $ sudo make install
 


### PR DESCRIPTION
Hello, 

While attempting to compile your project, I got the following error while attempting to build the example:
`error: ‘CreateGlutWindowAndBind’ is not a member of ‘pangolin’`

I had to re-compile Pangolin with the following command:
`cmake -DCPP11_NO_BOOST=1 -DFORCE_GLUT=1 ..`
